### PR TITLE
Deduplicating client instantiation/login

### DIFF
--- a/lib/clients/discord.js
+++ b/lib/clients/discord.js
@@ -1,0 +1,11 @@
+const { Client, GatewayIntentBits } = require('discord.js');
+
+const { DISCORD_TOKEN } = process.env;
+
+const DiscordClient = new Client({
+  intents: [GatewayIntentBits.GuildVoiceStates],
+});
+
+DiscordClient.login(DISCORD_TOKEN);
+
+module.exports = DiscordClient;

--- a/lib/listeners/discord.js
+++ b/lib/listeners/discord.js
@@ -1,7 +1,6 @@
-const { Client, GatewayIntentBits } = require('discord.js');
 const BaseListener = require('./base');
 
-const { DISCORD_TOKEN } = process.env;
+const DiscordClient = require('../clients/discord');
 
 class DiscordListener extends BaseListener {
   constructor(guildId, voiceChannelId) {
@@ -10,13 +9,7 @@ class DiscordListener extends BaseListener {
     this.guildId = guildId;
     this.voiceChannelId = voiceChannelId;
 
-    this.client = new Client({
-      intents: [GatewayIntentBits.GuildVoiceStates],
-    });
-
-    this.client.login(DISCORD_TOKEN);
-
-    this.client.on('voiceStateUpdate', (oldState, newState) => {
+    DiscordClient.on('voiceStateUpdate', (oldState, newState) => {
       const { channelId: oldChannel } = oldState;
       const { channelId: newChannel, member } = newState;
 
@@ -45,7 +38,7 @@ class DiscordListener extends BaseListener {
    * @return {Promise<Number>}
    */
   async memberCount() {
-    const { members } = await this.client.guilds.cache
+    const { members } = await DiscordClient.guilds.cache
       .get(this.guildId)
       .channels.fetch(this.voiceChannelId);
 


### PR DESCRIPTION
Discord was logging in twice, and only the first login was working. Since the productivity responder was instantiated first, only it was working. This memoizes the Discord client inside of its own module.