### PR TITLE
mounting secrets in a different way to avoid warnings

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,3 +4,5 @@ services:
     container_name: fren-bot
     build: .
     restart: unless-stopped
+    volumes:
+      - ./.env.production.local:/usr/src/app/.env.production.local


### PR DESCRIPTION
This PR changes how we get the `.env.production.local` file into the docker container. instead of using the `environment_file` directive to read the file and set environment variables from the file, we instead move to using a bind mount because dotenv-flow already kind of does that for us and it makes warnings go away in the logs which makes me happy.