### PR TITLE
Node.js version bump

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x, 15.x]
+        node-version: [18.x, 20.x] #LTS and Current as of 6/7/2023
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM node:20-alpine
+FROM node:lts-alpine
 
 WORKDIR /usr/src/app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM node:17-alpine
+FROM node:20-alpine
 
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
moving CI checks away from unsupported/maintenance versions and to LTS and Current versions of node.js as of 6/7/2023, and moving the docker image to 20.x which is the current version.

details here on which versions have what level of support:
https://github.com/nodejs/release#release-schedule