### PR TITLE
Only sending pings to gamer chat

### DIFF
--- a/contexts/gas_discord.js
+++ b/contexts/gas_discord.js
@@ -1,5 +1,9 @@
-const { DISCORD_RESPONDER_ENABLED, GAS_CHAT, GUILD_ID, VOICE_CHANNEL_ID } =
-  process.env;
+const {
+  DISCORD_RESPONDER_ENABLED,
+  GAS_GAMER_CHAT,
+  GUILD_ID,
+  VOICE_CHANNEL_ID,
+} = process.env;
 
 const telegram = require('../lib/senders/telegram');
 
@@ -13,7 +17,7 @@ if (DISCORD_RESPONDER_ENABLED === 'true') {
       plural ? 's' : ''
     } in the leb.`;
 
-    telegram.send(msg, GAS_CHAT);
+    telegram.send(msg, GAS_GAMER_CHAT);
   });
 
   const discord = new DiscordListener(GUILD_ID, VOICE_CHANNEL_ID);

--- a/contexts/gas_productivity.js
+++ b/contexts/gas_productivity.js
@@ -1,6 +1,6 @@
 const {
   PRODUCTIVITY_RESPONDER_ENABLED,
-  GAS_CHAT,
+  GAS_GAMER_CHAT,
   GUILD_ID,
   PRODUCTIVITY_CHANNEL_ID,
 } = process.env;
@@ -17,7 +17,7 @@ if (PRODUCTIVITY_RESPONDER_ENABLED === 'true') {
       plural ? 'are' : 'is'
     } being productive 😌.`;
 
-    telegram.send(msg, GAS_CHAT);
+    telegram.send(msg, GAS_GAMER_CHAT);
   });
 
   const discordProductivity = new DiscordListener(


### PR DESCRIPTION
We were setting `GAS_CHAT` to the gamer chat in the environment as a hack to fix this, but I figure we may as well just set this in the code for now.